### PR TITLE
TIP V5.2 update

### DIFF
--- a/content/cards/TIP/modal.md
+++ b/content/cards/TIP/modal.md
@@ -1,7 +1,7 @@
 ---
 id: TIP
 ---
-# TIP V5.0
+# TIP V5.2
 
 ## Temporal Interference Planning Tool of IT'IS
 
@@ -9,13 +9,13 @@ The Temporal Interference Planning (TIP) tool of the [IT'IS Foundation](https://
 
 TIP enables researchers to design and validate TI stimulation protocols without requiring deep expertise in computational modeling. It supports classic TI, multi-channel TI, and phase-modulation TI workflows, and is fully compatible with the TIBS-R system.
 
-TIP V5.0 builds on the personalization and optimization capabilities introduced in previous versions and adds three major advances:
+TIP V5.2 delivers a focused overhaul of the surrogate-model-based optimizer (SuMo) at the heart of TIP's electrode configuration search. All of the advanced features of TIP V5.0 are preserved — privacy-first local personalization, full Sim4Life workbench access in the Exposure Analysis step, and faster optimization — while three synergistic improvements produce higher-quality, richer Pareto fronts and give users direct control over the trade-off between speed and thoroughness:
 
-* Privacy-First Personalization: Magnetic resonance imaging (MRI) processing can now be performed locally using the new offline personalizer. Raw MRI data stay on the user's computer; only the anonymized, segmented model is uploaded to TIP for cloud-based simulation and optimization.
+* Native Constraint Handling: Impractical electrode configurations — such as two channels that share the same electrode — are now eliminated directly at the level of the algorithm, so that every configuration on the Pareto front is physically deployable.
 
-* Full Sim4Life Workbench Access: The Exposure Analysis step now provides access to a complete Sim4Life workbench, including modeling, simulation, and analysis functionality, with ready-to-use template projects for precomputed and personalized models.
+* Parallel Multi-Seed Optimization: Six independent searches run in parallel and are merged into a single, denser and richer Pareto front that covers the optimal trade-off surface more effectively, without increasing optimization time.
 
-* ~5× Faster Optimization: The surrogate-model-based SuMo optimizer now runs approximately five times faster, reducing typical optimization times from about one hour to 5–10 minutes.
+* Adaptive Convergence: The optimizer stops automatically once convergence is reached, allowing the user to choose the precision level — low, medium, or high — that best fits the workflow.
 
 TIP remains available through the TI Solutions Early Adopter Program and IT'IS research partnerships. Precomputed models can be explored without personalized simulation costs; personalized models require AWS simulation costs.
 
@@ -26,7 +26,7 @@ TIP remains available through the TI Solutions Early Adopter Program and IT'IS r
 
 Use subject-specific MRI and optional diffusion tensor imaging data to create personalized anatomical models for TI planning.
 
-With TIP V5.0, MRI processing can run locally using the offline personalizer. Raw MRI data stay on the user's computer; only the anonymized, segmented model is uploaded to TIP.
+With TIP V5.2, MRI processing can run locally using the offline personalizer. Raw MRI data stay on the user's computer; only the anonymized, segmented model is uploaded to TIP.
 
 ## Electromagnetic Simulations
 
@@ -51,9 +51,9 @@ Standardized 10–10 electrode placement supports reproducible planning while ke
 {{< modal-image tip_4.jpg >}}
 {{< /modal-image >}}
 
-Identify high-performing electrode configurations with the SuMo optimizer.
+Identify high-performing electrode configurations with the surrogate-model-based optimizer (SuMo).
 
-In TIP V5.0, optimization is approximately five times faster, reducing typical runtimes from about one hour to 5–10 minutes.
+In TIP V5.2, native constraint handling keeps the SuMo surface smooth and ensures every configuration on the Pareto front is physically deployable, parallel multi-seed execution delivers denser and richer Pareto fronts, and adaptive convergence lets you select low, medium, or high precision to balance speed against thoroughness.
 
 ## Visualization and Post-Processing
 
@@ -68,11 +68,11 @@ Visualize stimulation fields, phase modulation, pulse shapes, and field componen
 {{< modal-image tip_6.jpg >}}
 {{< /modal-image >}}
 
-TIP V5.0 provides ready-to-use template projects with anatomical models, targets, electrodes, and preconfigured simulations for deeper exposure analysis in a full-featured Sim4Life instance, including rendering, masking, streamlines, derived quantities, and reporting. 
+TIP V5.2 provides ready-to-use template projects with anatomical models, targets, electrodes, and preconfigured simulations for deeper exposure analysis in a full-featured Sim4Life instance, including rendering, masking, streamlines, derived quantities, and reporting. 
 
 ## Access
 
-TIP V5.0 is available to members of the TI Solutions Early Adopter Program and IT'IS research partners. For access, support, or further information, contact [tip@itis.swiss](mailto:tip@itis.swiss) or [eap@temporalinterference.com](mailto:eap@temporalinterference.com).
+TIP V5.2 is available to members of the TI Solutions Early Adopter Program and IT'IS research partners. For access, support, or further information, contact [tip@itis.swiss](mailto:tip@itis.swiss) or [eap@temporalinterference.com](mailto:eap@temporalinterference.com).
 
 ## Disclaimer
 


### PR DESCRIPTION
Updates the TIP card from V5.0 to V5.2 based on the officially approved TIP V5.2 marketing material.

Changes to `content/cards/TIP/modal.md`:
- Title bumped to **TIP V5.2**.
- Intro reframed around the focused SuMo optimizer overhaul, noting all V5.0 features are preserved, plus the three new highlights: native constraint handling, parallel multi-seed optimization, and adaptive convergence.
- "Optimal Configuration Identification" section updated to describe the new optimizer behavior (replacing the V5.0 "~5× faster" claim).
- Access section updated to V5.2, including the AWS cost note (~US$60 per personalized subject; precomputed models free).